### PR TITLE
refactor: render the API key panel as HTMX fragments

### DIFF
--- a/lambda/manage_keys/src/main.rs
+++ b/lambda/manage_keys/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fmt;
 
 use aws_sdk_dynamodb::types::AttributeValue;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -6,15 +7,18 @@ use base64::Engine;
 use chrono::Utc;
 use lambda_http::http::StatusCode;
 use lambda_http::request::RequestContext;
-use lambda_http::{run, service_fn, tracing, Error, Request, RequestExt};
+use lambda_http::{run, service_fn, tracing, Error, Request, RequestExt, RequestPayloadExt};
 use rand::rngs::OsRng;
 use rand::TryRngCore;
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use sha2::{Digest, Sha256};
 
 use shared::auth::owner_from_request;
 use shared::error::AppError;
-use shared::response::{empty_response, error_response, json_response};
+use shared::response::{
+    empty_response, error_response, html_response, html_response_with_trigger, json_response,
+};
+use shared::templates::{ApiKeyRow, ApiKeysList, ErrorPopup, NewApiKey, Template};
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -23,7 +27,73 @@ use shared::response::{empty_response, error_response, json_response};
 #[derive(Deserialize)]
 struct MintRequest {
     label: String,
+    #[serde(default, deserialize_with = "deserialize_optional_days")]
     expires_in_days: Option<u32>,
+}
+
+/// Deserializes `expires_in_days` from either a JSON number or an HTML form field,
+/// treating an EMPTY form value as "no expiry".
+///
+/// The mint form always submits `expires_in_days`, and submits it as an empty string when
+/// the user leaves the box blank -- which is both the default and the common case. A plain
+/// `Option<u32>` rejects `""` with a parse error, so "Create key" would fail with a 400 on
+/// exactly the path most people take, while JSON callers (which omit the field entirely)
+/// stayed green. That asymmetry is the reason this is a deserializer and not a bare Option.
+fn deserialize_optional_days<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct OptionalDays;
+
+    impl<'de> de::Visitor<'de> for OptionalDays {
+        type Value = Option<u32>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a whole number of days, or an empty value for no expiry")
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D2>(self, deserializer: D2) -> Result<Self::Value, D2::Error>
+        where
+            D2: Deserializer<'de>,
+        {
+            // A urlencoded field is always a string; the same field over JSON is a number.
+            // deserialize_any lets one visitor accept both without a serde(untagged) enum.
+            deserializer.deserialize_any(self)
+        }
+
+        fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            trimmed
+                .parse::<u32>()
+                .map(Some)
+                .map_err(|_| E::custom("expires_in_days must be a whole number of days"))
+        }
+
+        fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
+            u32::try_from(value)
+                .map(Some)
+                .map_err(|_| E::custom("expires_in_days is out of range"))
+        }
+
+        fn visit_i64<E: de::Error>(self, value: i64) -> Result<Self::Value, E> {
+            u32::try_from(value)
+                .map(Some)
+                .map_err(|_| E::custom("expires_in_days must not be negative"))
+        }
+    }
+
+    deserializer.deserialize_option(OptionalDays)
 }
 
 #[derive(Serialize)]
@@ -49,6 +119,99 @@ struct KeySummary {
 #[derive(Serialize)]
 struct ListResponse {
     keys: Vec<KeySummary>,
+}
+
+// ---------------------------------------------------------------------------
+// Content negotiation: HTML fragments for the page, JSON for scripts
+// ---------------------------------------------------------------------------
+//
+// The key panel is driven by htmx, exactly like the links table: the browser asks for a
+// fragment and swaps it into the page, so a key row's markup exists once, server-side,
+// instead of being rebuilt as an HTML string in JavaScript.
+//
+// JSON is NOT dropped. Every handler still answers JSON when the caller is not htmx, so
+// `/api/keys` remains a usable API for a script holding a Cognito JWT. The switch is the
+// `Hx-Request` header, which is the same rule create_link and get_links already use.
+
+impl From<&KeySummary> for ApiKeyRow {
+    fn from(summary: &KeySummary) -> Self {
+        ApiKeyRow {
+            key_id: summary.key_id.clone(),
+            prefix: summary.prefix.clone(),
+            label: summary.label.clone(),
+            last_used_at: summary.last_used_at,
+            expires_at: summary.expires_at,
+        }
+    }
+}
+
+/// htmx sets this header on every request it issues.
+fn is_htmx_request(event: &Request) -> bool {
+    event.headers().get("Hx-Request").is_some()
+}
+
+fn body_string(event: &Request) -> String {
+    match event.body() {
+        lambda_http::Body::Text(s) => s.clone(),
+        lambda_http::Body::Binary(b) => String::from_utf8(b.clone()).unwrap_or_default(),
+        lambda_http::Body::Empty => String::new(),
+        // `Body` is #[non_exhaustive], so a wildcard is required.
+        _ => String::new(),
+    }
+}
+
+/// Parses a mint request from either the htmx form post or a JSON API call.
+///
+/// `payload()` dispatches on Content-Type: `application/x-www-form-urlencoded` for the
+/// form, `application/json` for scripts. It answers `Ok(None)` for anything else --
+/// including a request carrying NO Content-Type at all, which the previous version of this
+/// handler accepted because it parsed the raw body as JSON unconditionally. The fallback
+/// preserves that caller rather than turning it into a fresh 400.
+fn parse_mint_request(event: &Request) -> Result<MintRequest, AppError> {
+    let invalid =
+        || AppError::Validation("Invalid request body: expected a 'label' field".into());
+
+    match event.payload::<MintRequest>() {
+        Ok(Some(req)) => Ok(req),
+        Ok(None) => serde_json::from_str(&body_string(event)).map_err(|_| invalid()),
+        Err(_) => Err(invalid()),
+    }
+}
+
+fn render_key_list(keys: &[KeySummary]) -> Result<String, Error> {
+    let rows: Vec<ApiKeyRow> = keys.iter().map(ApiKeyRow::from).collect();
+    Ok(ApiKeysList { keys: rows }.render()?)
+}
+
+/// Renders a failure the way its caller can actually consume it.
+///
+/// For htmx that means an HTML fragment with a **200** status. htmx does not swap a 4xx or
+/// 5xx response, so returning the error's real status would render nothing at all and the
+/// user would watch the click do nothing. create_link already makes this trade for its own
+/// error popup.
+///
+/// Note this is for *business* failures only -- a bad label, a bad expiry, the key cap.
+/// Authentication failures must keep their real 401/403 status, because the page's auth
+/// layer keys its token-refresh-and-retry on exactly those codes; wrapping one in a 200
+/// would leave a stale session with no way to notice.
+fn key_error_response(
+    err: &AppError,
+    htmx: bool,
+) -> Result<lambda_http::Response<lambda_http::Body>, Error> {
+    if !htmx {
+        return error_response(err);
+    }
+
+    // Mirrors error_response's masking rule. Variants like Internal(String) interpolate
+    // their argument, and an HTML fragment is exactly as public as a JSON body -- rendering
+    // a 5xx verbatim would put a table name on the page.
+    let message = if err.status_code().is_server_error() {
+        "Something went wrong".to_string()
+    } else {
+        err.to_string()
+    };
+
+    html_response(&StatusCode::OK, ErrorPopup { message }.render()?)
 }
 
 // ---------------------------------------------------------------------------
@@ -272,21 +435,18 @@ impl KeyStore {
 async fn handle_mint(
     store: &KeyStore,
     owner_id: &str,
-    body: &str,
+    event: &Request,
+    htmx: bool,
 ) -> Result<lambda_http::Response<lambda_http::Body>, Error> {
-    // Parse request body
-    let req: MintRequest = match serde_json::from_str(body) {
+    // Accepts the htmx form post and a JSON body alike.
+    let req = match parse_mint_request(event) {
         Ok(r) => r,
-        Err(_) => {
-            return error_response(&AppError::Validation(
-                "Invalid request body: expected JSON with 'label' field".into(),
-            ));
-        }
+        Err(e) => return key_error_response(&e, htmx),
     };
 
     // Validate label
     if req.label.trim().is_empty() {
-        return error_response(&AppError::Validation("Label must not be empty".into()));
+        return key_error_response(&AppError::Validation("Label must not be empty".into()), htmx);
     }
 
     // Validate expires_in_days and convert to an absolute timestamp in one place, so the
@@ -294,15 +454,16 @@ async fn handle_mint(
     let now = Utc::now().timestamp();
     let expires_at = match expiry_from_days(req.expires_in_days, now) {
         Ok(expiry) => expiry,
-        Err(e) => return error_response(&e),
+        Err(e) => return key_error_response(&e, htmx),
     };
 
     // Enforce 10-key cap
     let count = store.count_owner_keys(owner_id).await?;
     if count >= MAX_KEYS_PER_OWNER {
-        return error_response(&AppError::Validation(format!(
-            "Maximum of {MAX_KEYS_PER_OWNER} API keys reached"
-        )));
+        return key_error_response(
+            &AppError::Validation(format!("Maximum of {MAX_KEYS_PER_OWNER} API keys reached")),
+            htmx,
+        );
     }
 
     // Generate key
@@ -314,6 +475,22 @@ async fn handle_mint(
     store
         .put_key(&key_hash, owner_id, &req.label, &prefix, now, expires_at)
         .await?;
+
+    if htmx {
+        let body = NewApiKey {
+            key: plaintext,
+            label: req.label,
+            expires_at,
+        }
+        .render()?;
+
+        // The new-key banner is this response's swap target, but the key list below it now
+        // has a row it does not know about -- and the list is not the target, so the
+        // fragment cannot reach it. `HX-Trigger` names an event the list is subscribed to,
+        // which keeps "a successful mint also changes the list" a fact the SERVER states
+        // rather than a consequence hardcoded into the page.
+        return html_response_with_trigger(&StatusCode::CREATED, body, "key-minted");
+    }
 
     let response = MintResponse {
         key: plaintext,
@@ -327,8 +504,17 @@ async fn handle_mint(
     json_response(&StatusCode::CREATED, &response)
 }
 
-async fn handle_list(store: &KeyStore, owner_id: &str) -> Result<lambda_http::Response<lambda_http::Body>, Error> {
+async fn handle_list(
+    store: &KeyStore,
+    owner_id: &str,
+    htmx: bool,
+) -> Result<lambda_http::Response<lambda_http::Body>, Error> {
     let keys = store.list_keys(owner_id).await?;
+
+    if htmx {
+        return html_response(&StatusCode::OK, render_key_list(&keys)?);
+    }
+
     let response = ListResponse { keys };
     json_response(&StatusCode::OK, &response)
 }
@@ -337,6 +523,7 @@ async fn handle_revoke(
     store: &KeyStore,
     owner_id: &str,
     key_id: &str,
+    htmx: bool,
 ) -> Result<lambda_http::Response<lambda_http::Body>, Error> {
     // Verify the key exists AND belongs to this owner.
     // If not found or owner mismatch, return 403 — never reveal existence.
@@ -345,9 +532,31 @@ async fn handle_revoke(
     match stored_owner {
         Some(ref owner) if owner == owner_id => {
             store.delete_key(key_id).await?;
+
+            if htmx {
+                // Answer with the re-rendered list rather than 204: htmx explicitly skips
+                // the swap on a 204, so the revoked row would sit on screen until a reload.
+                let keys = store.list_keys(owner_id).await?;
+                return html_response(&StatusCode::OK, render_key_list(&keys)?);
+            }
+
             empty_response(&StatusCode::NO_CONTENT)
         }
-        _ => error_response(&AppError::Forbidden),
+        _ => {
+            // A JSON caller gets the 403 it deserves. For htmx, the only way to reach this
+            // from the page is a list that has gone stale -- the key was already revoked in
+            // another tab -- and swapping an error box in would DESTROY the list, since the
+            // list is the swap target. Re-rendering it instead self-corrects: the row the
+            // user clicked is already gone, which is the outcome they asked for. Nothing is
+            // deleted on this path either way, so the ownership check is still the gate.
+            if htmx {
+                tracing::warn!("htmx revoke for a key this owner does not hold; re-rendering list");
+                let keys = store.list_keys(owner_id).await?;
+                return html_response(&StatusCode::OK, render_key_list(&keys)?);
+            }
+
+            key_error_response(&AppError::Forbidden, htmx)
+        }
     }
 }
 
@@ -440,31 +649,28 @@ async fn function_handler(
         Ok(sub) => sub,
         Err(e) => {
             tracing::error!("rejecting request without owner identity: {:?}", e);
+            // Deliberately NOT key_error_response: an auth failure must keep its real
+            // 401/403, because the page's auth layer triggers its token refresh and retry
+            // off those exact codes. Dressing this one up as a 200 HTML fragment would
+            // leave a merely-expired session looking like a permanent failure.
             return error_response(&e);
         }
     };
 
     let path = path_for_routing(&event);
+    let htmx = is_htmx_request(&event);
 
     match route_of(event.method().as_str(), &path) {
-        Route::Mint => {
-            let body = match event.body() {
-                lambda_http::Body::Text(s) => s.clone(),
-                lambda_http::Body::Binary(b) => {
-                    String::from_utf8(b.clone()).unwrap_or_default()
-                }
-                lambda_http::Body::Empty => String::new(),
-                // `Body` is #[non_exhaustive], so a wildcard is required.
-                _ => String::new(),
-            };
-            handle_mint(store, &owner_id, &body).await
-        }
-        Route::List => handle_list(store, &owner_id).await,
+        Route::Mint => handle_mint(store, &owner_id, &event, htmx).await,
+        Route::List => handle_list(store, &owner_id, htmx).await,
         Route::Revoke(key_id) => {
             if key_id.is_empty() {
-                return error_response(&AppError::Validation("Key ID is required".into()));
+                return key_error_response(
+                    &AppError::Validation("Key ID is required".into()),
+                    htmx,
+                );
             }
-            handle_revoke(store, &owner_id, &key_id).await
+            handle_revoke(store, &owner_id, &key_id, htmx).await
         }
         Route::NotAllowed => {
             tracing::warn!("no route for {} {}", event.method(), path);
@@ -608,6 +814,22 @@ mod tests {
     /// production still returned 405 for every request. The fixture has to look the way
     /// production actually looks or it proves nothing.
     fn staged_event(method: &str, path_after_stage: &str, body: &str) -> Request {
+        staged_event_with_headers(
+            method,
+            path_after_stage,
+            body,
+            r#"{ "content-type": "application/json" }"#,
+        )
+    }
+
+    /// As above, with the headers under test control. They decide two separate things: the
+    /// Content-Type picks the body parser, and `Hx-Request` picks the response format.
+    fn staged_event_with_headers(
+        method: &str,
+        path_after_stage: &str,
+        body: &str,
+        headers_json: &str,
+    ) -> Request {
         let raw_path = format!("/prod{path_after_stage}");
         let json = format!(
             r#"{{
@@ -615,7 +837,7 @@ mod tests {
               "routeKey": "{method} /api/keys",
               "rawPath": "{raw_path}",
               "rawQueryString": "",
-              "headers": {{ "content-type": "application/json" }},
+              "headers": {headers_json},
               "body": {body:?},
               "isBase64Encoded": false,
               "requestContext": {{
@@ -641,6 +863,10 @@ mod tests {
         );
         lambda_http::request::from_str(&json).expect("fixture should deserialize")
     }
+
+    /// What the htmx mint form actually sends.
+    const FORM_HEADERS: &str =
+        r#"{ "content-type": "application/x-www-form-urlencoded", "hx-request": "true" }"#;
 
     /// The regression test for the 405-on-everything bug.
     ///
@@ -734,5 +960,173 @@ mod tests {
             route_of("DELETE", "/api/keys/"),
             Route::Revoke(String::new())
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Body parsing: the htmx form and the JSON API share one handler
+    // -----------------------------------------------------------------------
+
+    /// The exact request the mint form sends when the expiry box is left empty, which is
+    /// the default path through the UI. A bare `Option<u32>` rejects `expires_in_days=`
+    /// with a parse error, so this would 400 on the most common case while JSON callers
+    /// (which omit the field entirely) stayed green.
+    #[test]
+    fn mint_accepts_a_form_post_with_a_blank_expiry() {
+        let event = staged_event_with_headers(
+            "POST",
+            "/api/keys",
+            "label=laptop+CLI&expires_in_days=",
+            FORM_HEADERS,
+        );
+        let req = parse_mint_request(&event).expect("a blank expiry must parse, not fail");
+        assert_eq!(req.label, "laptop CLI");
+        assert_eq!(req.expires_in_days, None);
+    }
+
+    #[test]
+    fn mint_accepts_a_form_post_with_an_expiry() {
+        let event = staged_event_with_headers(
+            "POST",
+            "/api/keys",
+            "label=ci+runner&expires_in_days=30",
+            FORM_HEADERS,
+        );
+        let req = parse_mint_request(&event).expect("form body should parse");
+        assert_eq!(req.label, "ci runner");
+        assert_eq!(req.expires_in_days, Some(30));
+    }
+
+    /// The JSON contract must survive the move to fragments -- `/api/keys` is still an API.
+    #[test]
+    fn mint_still_accepts_json_from_scripts() {
+        let with_expiry =
+            staged_event("POST", "/api/keys", r#"{"label":"ci","expires_in_days":30}"#);
+        assert_eq!(
+            parse_mint_request(&with_expiry).unwrap().expires_in_days,
+            Some(30)
+        );
+
+        let without = staged_event("POST", "/api/keys", r#"{"label":"ci"}"#);
+        assert_eq!(parse_mint_request(&without).unwrap().expires_in_days, None);
+    }
+
+    /// The previous handler parsed the raw body as JSON regardless of Content-Type, so a
+    /// caller that sent none still worked. Keep that rather than introducing a new 400.
+    #[test]
+    fn mint_accepts_json_with_no_content_type_at_all() {
+        let event = staged_event_with_headers("POST", "/api/keys", r#"{"label":"ci"}"#, "{}");
+        assert_eq!(parse_mint_request(&event).unwrap().label, "ci");
+    }
+
+    #[test]
+    fn mint_rejects_a_non_numeric_expiry() {
+        let event = staged_event_with_headers(
+            "POST",
+            "/api/keys",
+            "label=ci&expires_in_days=soon",
+            FORM_HEADERS,
+        );
+        assert!(matches!(
+            parse_mint_request(&event),
+            Err(AppError::Validation(_))
+        ));
+    }
+
+    #[test]
+    fn mint_rejects_a_body_with_no_label() {
+        let event = staged_event("POST", "/api/keys", r#"{"expires_in_days":30}"#);
+        assert!(matches!(
+            parse_mint_request(&event),
+            Err(AppError::Validation(_))
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // Content negotiation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn htmx_is_detected_from_the_request_header() {
+        let from_page = staged_event_with_headers(
+            "GET",
+            "/api/keys",
+            "",
+            r#"{ "hx-request": "true" }"#,
+        );
+        assert!(is_htmx_request(&from_page));
+        // A script sends no such header and must keep getting JSON.
+        assert!(!is_htmx_request(&staged_event("GET", "/api/keys", "")));
+    }
+
+    #[test]
+    fn key_list_fragment_carries_a_revoke_control_per_key() {
+        let keys = vec![
+            KeySummary {
+                key_id: "hash-one".into(),
+                prefix: "krtk_aaaaaaa".into(),
+                label: "laptop CLI".into(),
+                created_at: 10,
+                last_used_at: None,
+                expires_at: None,
+            },
+            KeySummary {
+                key_id: "hash-two".into(),
+                prefix: "krtk_bbbbbbb".into(),
+                label: "ci runner".into(),
+                created_at: 20,
+                last_used_at: Some(1_739_035_776),
+                expires_at: Some(1_739_035_776),
+            },
+        ];
+
+        let html = render_key_list(&keys).expect("list fragment should render");
+        assert!(html.contains("hx-delete=\"/api/keys/hash-one\""));
+        assert!(html.contains("hx-delete=\"/api/keys/hash-two\""));
+        assert!(html.contains("laptop CLI"));
+        assert!(html.contains("ci runner"));
+        // The plaintext key is unrecoverable by construction, so it can never appear here.
+        assert!(!html.contains("krtk_aaaaaaabbbb"));
+    }
+
+    #[test]
+    fn htmx_business_errors_come_back_as_a_swappable_fragment() {
+        let resp =
+            key_error_response(&AppError::Validation("Label must not be empty".into()), true)
+                .unwrap();
+        // 200 on purpose: htmx does not swap a 4xx, so the error's real status would render
+        // nothing and the user would watch the click do nothing at all.
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers()["content-type"], "text/html");
+        match resp.body() {
+            lambda_http::Body::Text(t) => {
+                assert!(t.contains("Label must not be empty"), "got {t}")
+            }
+            other => panic!("expected a text body, got {other:?}"),
+        }
+    }
+
+    /// The HTML path must mask internal detail exactly as the JSON path does -- a fragment
+    /// is just as public as a JSON body.
+    #[test]
+    fn htmx_server_errors_do_not_leak_their_detail() {
+        let resp = key_error_response(
+            &AppError::Internal("apiKeyTable-prod-xyz timed out".into()),
+            true,
+        )
+        .unwrap();
+        match resp.body() {
+            lambda_http::Body::Text(t) => {
+                assert!(!t.contains("apiKeyTable"), "internal detail leaked: {t}");
+                assert!(t.contains("Something went wrong"), "got {t}");
+            }
+            other => panic!("expected a text body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_callers_keep_the_real_status_code() {
+        let resp = key_error_response(&AppError::Forbidden, false).unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(resp.headers()["content-type"], "application/json");
     }
 }

--- a/shared/src/response.rs
+++ b/shared/src/response.rs
@@ -54,6 +54,32 @@ pub fn html_response(status: &StatusCode, body: String) -> Result<Response<Body>
     Ok(response)
 }
 
+/// Respond with an HTML fragment **and** an `HX-Trigger` header, which asks htmx to fire
+/// a named client-side event once the response arrives.
+///
+/// This is how one response updates a second, unrelated region of the page. Minting an
+/// API key swaps the new-key banner into its own target, and the key list needs to
+/// re-fetch itself -- but the list is not the swap target and the fragment cannot reach
+/// it. Naming the event here puts "what else a successful mint changes" in the response,
+/// where the server decides it, instead of hardcoding the consequence into the page.
+///
+/// The event is dispatched on the element that made the request and bubbles, so a
+/// listener elsewhere subscribes with htmx's `from:` modifier (`refreshKeys from:body`).
+pub fn html_response_with_trigger(
+    status: &StatusCode,
+    body: String,
+    trigger_event: &str,
+) -> Result<Response<Body>, Error> {
+    let response = Response::builder()
+        .status(status)
+        .header("content-type", "text/html")
+        .header("HX-Trigger", trigger_event)
+        .body(Body::Text(body))
+        .map_err(Box::new)?;
+
+    Ok(response)
+}
+
 /// Respond with the status an [`AppError`] maps to, and a JSON `{"error": ...}` body.
 ///
 /// Client errors (4xx) return the error's own message, because the caller can act on
@@ -127,5 +153,17 @@ mod tests {
             }
             other => panic!("expected a text body, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn html_response_with_trigger_sets_the_hx_trigger_header() {
+        let resp =
+            html_response_with_trigger(&StatusCode::CREATED, "<p>ok</p>".to_string(), "key-minted")
+                .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert_eq!(resp.headers()["content-type"], "text/html");
+        // htmx reads this header verbatim as the event name to dispatch, so a typo or a
+        // wrapped value silently does nothing at all.
+        assert_eq!(resp.headers()["HX-Trigger"], "key-minted");
     }
 }

--- a/shared/src/templates.rs
+++ b/shared/src/templates.rs
@@ -53,6 +53,44 @@ pub struct ErrorPopup {
     pub message: String,
 }
 
+// --- API keys
+//
+// The key management panel is server-rendered for the same reason the links table is:
+// the browser asks for a fragment and swaps it in, so the shape of a key row lives in
+// exactly one place instead of being duplicated as an HTML string in JavaScript.
+//
+// Deliberately no `created_at` here. The list is ordered by it, but the previous
+// client-side panel never displayed it, and rendering a field nobody asked for would
+// make this refactor a behaviour change.
+
+/// One row in the key list. Never carries the plaintext key -- only the hash is stored,
+/// so there is nothing to leak here even by accident.
+#[derive(Debug)]
+pub struct ApiKeyRow {
+    /// The SHA-256 hash, which is also the table's partition key and therefore the id
+    /// used in the revoke URL.
+    pub key_id: String,
+    pub prefix: String,
+    pub label: String,
+    pub last_used_at: Option<i64>,
+    pub expires_at: Option<i64>,
+}
+
+#[derive(Template, Debug)]
+#[template(path = "api_keys_list.html")]
+pub struct ApiKeysList {
+    pub keys: Vec<ApiKeyRow>,
+}
+
+/// The one-time display of a freshly minted key.
+#[derive(Template, Debug)]
+#[template(path = "new_api_key.html")]
+pub struct NewApiKey {
+    pub key: String,
+    pub label: String,
+    pub expires_at: Option<i64>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -133,5 +171,115 @@ mod tests {
         // Auto-escaping must remain on for .html templates after the upgrade.
         assert!(!rendered.contains("<script>"));
         assert!(rendered.contains("&#60;script&#62;") || rendered.contains("&lt;script&gt;"));
+    }
+
+    // -----------------------------------------------------------------------
+    // API key fragments
+    // -----------------------------------------------------------------------
+
+    fn key_row(label: &str, last_used_at: Option<i64>, expires_at: Option<i64>) -> ApiKeyRow {
+        ApiKeyRow {
+            key_id: "a".repeat(64),
+            prefix: "krtk_3f9aQ2x".to_string(),
+            label: label.to_string(),
+            last_used_at,
+            expires_at,
+        }
+    }
+
+    #[test]
+    fn key_list_renders_a_revoke_control_addressed_by_key_id() {
+        let rendered = ApiKeysList { keys: vec![key_row("laptop CLI", None, None)] }
+            .render()
+            .expect("ApiKeysList should render");
+
+        // The revoke affordance is a hypermedia control in the response, not a URL the
+        // client assembles -- that is the whole point of the refactor.
+        assert!(
+            rendered.contains(&format!("hx-delete=\"/api/keys/{}\"", "a".repeat(64))),
+            "expected an hx-delete control, got: {rendered}"
+        );
+        assert!(rendered.contains("hx-target=\"#key-list\""));
+        assert!(rendered.contains("laptop CLI"));
+        assert!(rendered.contains("krtk_3f9aQ2x"));
+    }
+
+    #[test]
+    fn key_list_renders_absent_timestamps_as_words_not_epoch_zero() {
+        // The client-side version fed epoch SECONDS to a millisecond Date constructor and
+        // rendered "1/1/1970" for keys with an expiry. Formatting server-side removes the
+        // unit ambiguity, so pin both the absent and present cases.
+        let rendered = ApiKeysList {
+            keys: vec![key_row("no dates", None, None)],
+        }
+        .render()
+        .expect("ApiKeysList should render");
+        assert!(rendered.contains("no expiry"));
+        assert!(rendered.contains("never used"));
+        assert!(!rendered.contains("1970"));
+
+        let dated = ApiKeysList {
+            keys: vec![key_row("dated", Some(1_739_035_776), Some(1_739_035_776))],
+        }
+        .render()
+        .expect("ApiKeysList should render");
+        assert!(dated.contains("expires 2025-02-08 17:29:36 UTC"), "got: {dated}");
+        assert!(dated.contains("last used 2025-02-08 17:29:36 UTC"), "got: {dated}");
+    }
+
+    #[test]
+    fn empty_key_list_renders_its_own_empty_state() {
+        // The empty state has to come from the fragment: the panel swaps this template in
+        // wholesale, so a separately-managed empty <p> in the page would never update.
+        let rendered = ApiKeysList { keys: vec![] }
+            .render()
+            .expect("ApiKeysList should render");
+        assert!(rendered.contains("No API keys."));
+        assert!(!rendered.contains("hx-delete"));
+    }
+
+    #[test]
+    fn key_list_escapes_a_label_containing_markup() {
+        // A label is free text the user chose, and it lands in both element content and an
+        // hx-confirm ATTRIBUTE. An unescaped quote in the attribute would end it early.
+        let rendered = ApiKeysList {
+            keys: vec![key_row("<img src=x onerror=alert(1)>\" evil", None, None)],
+        }
+        .render()
+        .expect("ApiKeysList should render");
+        assert!(!rendered.contains("<img"), "label markup was not escaped: {rendered}");
+        assert!(
+            !rendered.contains("evil\""),
+            "a raw quote survived into the attribute: {rendered}"
+        );
+    }
+
+    #[test]
+    fn new_api_key_shows_the_plaintext_and_the_shown_once_warning() {
+        let rendered = NewApiKey {
+            key: "krtk_abc123".to_string(),
+            label: "laptop CLI".to_string(),
+            expires_at: Some(1_739_035_776),
+        }
+        .render()
+        .expect("NewApiKey should render");
+        assert!(rendered.contains("krtk_abc123"));
+        assert!(rendered.contains("will not be shown again"));
+        assert!(rendered.contains("expires 2025-02-08 17:29:36 UTC"));
+        // The copy control reuses the page's existing helper rather than a second one.
+        assert!(rendered.contains("copyToClipboard('krtk_abc123')"));
+    }
+
+    #[test]
+    fn new_api_key_without_expiry_says_so() {
+        let rendered = NewApiKey {
+            key: "krtk_abc123".to_string(),
+            label: "forever".to_string(),
+            expires_at: None,
+        }
+        .render()
+        .expect("NewApiKey should render");
+        assert!(rendered.contains("no expiry"));
+        assert!(!rendered.contains("1970"));
     }
 }

--- a/shared/templates/api_keys_list.html
+++ b/shared/templates/api_keys_list.html
@@ -1,0 +1,26 @@
+{% if keys.is_empty() %}
+<p class="text-sm text-gray-500 dark:text-gray-400 italic">No API keys.</p>
+{% else %}
+{% for key in keys %}
+<div class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-md">
+  <div>
+    <span class="text-sm font-medium">{{ key.label }}</span>
+    <code class="text-xs text-gray-500 dark:text-gray-400">{{ key.prefix }}…</code>
+    <br>
+    <span class="text-xs text-gray-500 dark:text-gray-400">
+      {% if let Some(expires_at) = key.expires_at %}expires {{ expires_at|format_timestamp }}{% else %}no expiry{% endif %}
+      ·
+      {% if let Some(last_used_at) = key.last_used_at %}last used {{ last_used_at|format_timestamp }}{% else %}never used{% endif %}
+    </span>
+  </div>
+  {# The revoke button re-renders the WHOLE list rather than removing its own row: the
+     empty state ("No API keys.") is rendered by this template, so an outerHTML swap that
+     deleted the last row would leave an empty container with no empty state in it. #}
+  <button hx-delete="/api/keys/{{ key.key_id }}"
+          hx-target="#key-list"
+          hx-swap="innerHTML"
+          hx-confirm="Revoke '{{ key.label }}'? Any script using this key stops working immediately."
+          class="text-sm text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 underline">Revoke</button>
+</div>
+{% endfor %}
+{% endif %}

--- a/shared/templates/new_api_key.html
+++ b/shared/templates/new_api_key.html
@@ -1,0 +1,19 @@
+{# The plaintext key appears in this fragment and nowhere else, ever again: only the
+   SHA-256 hash is stored, so the list fragment cannot re-render it. That is what makes
+   "shown once" (FR-5.7) a property of the data rather than a promise the UI keeps. #}
+<div class="p-4 bg-green-100 dark:bg-green-900/40 border border-green-300 dark:border-green-700 rounded-lg">
+  <p class="text-sm font-medium text-green-800 dark:text-green-200 mb-2">
+    ⚠️ Copy this key now — it will not be shown again.
+  </p>
+  <code class="block p-2 bg-white dark:bg-gray-800 border dark:border-gray-600 rounded text-sm font-mono break-all">{{ key }}</code>
+  <div class="flex items-center justify-between mt-2">
+    <button type="button"
+            onclick="copyToClipboard('{{ key }}')"
+            class="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline">
+        Copy to clipboard
+    </button>
+    <span class="text-xs text-gray-600 dark:text-gray-400">
+      {{ label }}{% if let Some(expires_at) = expires_at %} · expires {{ expires_at|format_timestamp }}{% else %} · no expiry{% endif %}
+    </span>
+  </div>
+</div>

--- a/website/assets/main.js
+++ b/website/assets/main.js
@@ -68,165 +68,17 @@ if (document.readyState === 'loading') {
 }
 
 // --- API Key Management (FR-5.7) --------------------------------------------
-
-async function mintApiKey() {
-    var labelInput = document.getElementById('key-label-input');
-    var expiryInput = document.getElementById('key-expiry-input');
-    var label = (labelInput.value || '').trim();
-    if (!label) {
-        showNotification('Please enter a label for the key');
-        return;
-    }
-
-    var body = { label: label };
-    var expiryDays = parseInt(expiryInput.value, 10);
-    if (expiryDays > 0 && expiryDays <= 365) {
-        body.expires_in_days = expiryDays;
-    }
-
-    try {
-        var token = await window.krtk.getValidAccessToken();
-        var resp = await fetch('/api/keys', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': 'Bearer ' + token,
-            },
-            body: JSON.stringify(body),
-        });
-
-        if (resp.status === 401) {
-            await window.krtk.signOut();
-            return;
-        }
-        if (!resp.ok) {
-            var errData = await resp.text();
-            showNotification('Failed to create key: ' + (errData || resp.status));
-            return;
-        }
-
-        var data = await resp.json();
-        // Show the key exactly once (FR-5.7)
-        var resultDiv = document.getElementById('key-mint-result');
-        var valueEl = document.getElementById('key-mint-value');
-        valueEl.textContent = data.key;
-        resultDiv.classList.remove('hidden');
-
-        // Reset form
-        labelInput.value = '';
-        expiryInput.value = '';
-
-        // Refresh key list
-        loadApiKeys();
-    } catch (e) {
-        showNotification('Error creating key: ' + e.message);
-    }
-}
-
-function copyApiKey() {
-    var valueEl = document.getElementById('key-mint-value');
-    if (valueEl) {
-        navigator.clipboard.writeText(valueEl.textContent).then(function () {
-            showNotification('API key copied to clipboard!');
-        });
-    }
-}
-
-async function revokeApiKey(keyId) {
-    try {
-        var token = await window.krtk.getValidAccessToken();
-        var resp = await fetch('/api/keys/' + encodeURIComponent(keyId), {
-            method: 'DELETE',
-            headers: { 'Authorization': 'Bearer ' + token },
-        });
-        if (resp.status === 401) {
-            await window.krtk.signOut();
-            return;
-        }
-        if (!resp.ok) {
-            showNotification('Failed to revoke key');
-            return;
-        }
-        showNotification('Key revoked');
-        loadApiKeys();
-    } catch (e) {
-        showNotification('Error revoking key: ' + e.message);
-    }
-}
-
-async function loadApiKeys() {
-    var listEl = document.getElementById('key-list');
-    var emptyEl = document.getElementById('key-list-empty');
-    if (!listEl) return;
-
-    try {
-        var token = await window.krtk.getValidAccessToken();
-        var resp = await fetch('/api/keys', {
-            headers: { 'Authorization': 'Bearer ' + token },
-        });
-        if (resp.status === 401) {
-            await window.krtk.signOut();
-            return;
-        }
-        if (!resp.ok) {
-            listEl.innerHTML = '<p class="text-sm text-red-500">Failed to load keys</p>';
-            return;
-        }
-
-        var data = await resp.json();
-        var keys = data.keys || [];
-
-        if (keys.length === 0) {
-            listEl.innerHTML = '';
-            if (emptyEl) emptyEl.classList.remove('hidden');
-            return;
-        }
-
-        if (emptyEl) emptyEl.classList.add('hidden');
-        listEl.innerHTML = keys.map(function (k) {
-            var expiry = k.expires_at
-                ? '<span class="text-xs text-gray-500 dark:text-gray-400">expires ' + formatEpochSeconds(k.expires_at) + '</span>'
-                : '<span class="text-xs text-gray-500 dark:text-gray-400">no expiry</span>';
-            var lastUsed = k.last_used_at
-                ? 'Last used ' + formatEpochSeconds(k.last_used_at)
-                : 'Never used';
-            return '<div class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-md">' +
-                '<div>' +
-                    '<span class="text-sm font-medium">' + escapeHtml(k.label) + '</span>' +
-                    ' <code class="text-xs text-gray-500 dark:text-gray-400">' + escapeHtml(k.prefix) + '…</code>' +
-                    '<br>' + expiry + ' · <span class="text-xs text-gray-500 dark:text-gray-400">' + lastUsed + '</span>' +
-                '</div>' +
-                '<button onclick="revokeApiKey(\'' + escapeHtml(k.key_id) + '\')" ' +
-                    'class="text-sm text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 underline">Revoke</button>' +
-            '</div>';
-        }).join('');
-    } catch (e) {
-        listEl.innerHTML = '<p class="text-sm text-red-500">Error loading keys</p>';
-    }
-}
-
-// The key API returns Unix timestamps in SECONDS (Rust's `Utc::now().timestamp()`), but
-// the Date constructor takes MILLISECONDS. Passing the raw value renders every date as
-// January 1970, which looks like corrupt data rather than a unit mismatch.
-function formatEpochSeconds(epochSeconds) {
-    return new Date(epochSeconds * 1000).toLocaleDateString();
-}
-
-// Coerces null/undefined to an empty string. createTextNode(undefined) stringifies to the
-// literal word "undefined" and renders it as content, so a field this code names wrongly
-// shows up as plausible-looking text in the UI instead of visibly breaking.
-function escapeHtml(str) {
-    var div = document.createElement('div');
-    div.appendChild(document.createTextNode(str == null ? '' : String(str)));
-    return div.innerHTML;
-}
-
-// Load keys on page ready (only if authenticated — auth.js calls showAuthenticatedUI first)
-document.addEventListener('DOMContentLoaded', function () {
-    // Delay key load slightly so auth init has time to show the UI
-    setTimeout(function () {
-        if (window.krtk && window.krtk.isAuthenticated()) {
-            loadApiKeys();
-        }
-    }, 100);
-});
+//
+// Intentionally empty. The key panel is server-rendered htmx fragments: mint, list and
+// revoke are hx-post / hx-get / hx-delete attributes in index.html, the markup for a key
+// row lives in shared/templates/api_keys_list.html, and the Bearer token is attached by
+// the htmx:configRequest listener in auth.js like every other /api/* call.
+//
+// What used to be here -- fetch() calls, an innerHTML row builder, an escapeHtml helper and
+// an epoch-seconds date formatter -- were all consequences of rendering the panel in the
+// browser. Two of them had already produced defects (a field named `key_prefix` that the
+// API calls `prefix`, and seconds fed to a millisecond Date constructor). Rendering
+// server-side deletes the class of bug rather than the instances.
+//
+// The one remaining browser-only need, copying a freshly minted key, reuses
+// copyToClipboard() above -- the same helper the links table has always used.

--- a/website/index.html
+++ b/website/index.html
@@ -150,56 +150,82 @@
 
                     </div>
 
-                    <!-- API Key Management (FR-5.7) -->
+                    <!-- API Key Management (FR-5.7)
+                         Driven by htmx exactly like the links table above: the server owns
+                         the markup for a key row and the browser swaps in fragments. There
+                         is no JavaScript behind this panel -- the two controls that need a
+                         browser API (clipboard, confirm) use the page's existing helper and
+                         htmx's own hx-confirm. -->
                     <div class="mt-10 border-t border-gray-200 dark:border-gray-700 pt-6">
                         <h3 class="text-xl font-semibold mb-4">API Keys</h3>
                         <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
                             API keys let you create and list links from scripts and CLI tools without a browser session.
                         </p>
 
-                        <!-- Mint new key form -->
-                        <div id="key-mint-form" class="mb-6 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
+                        <!-- Mint. The response is the new-key banner for #key-mint-result,
+                             plus an `HX-Trigger: key-minted` header. The list below is
+                             subscribed to that event, so the server decides that a mint also
+                             refreshes the list; this form does not have to know. The form is
+                             reset by the same event, which means a REJECTED mint (a bad
+                             expiry, the 10-key cap) keeps what you typed. -->
+                        <form id="key-mint-form"
+                              hx-post="/api/keys"
+                              hx-target="#key-mint-result"
+                              hx-swap="innerHTML"
+                              hx-indicator="#key-mint-loader"
+                              hx-on:key-minted="this.reset()"
+                              class="mb-6 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
                             <h4 class="text-sm font-medium mb-3">Create a new API key</h4>
                             <div class="flex gap-3 flex-wrap">
                                 <input type="text"
+                                       name="label"
                                        id="key-label-input"
                                        placeholder="Label (e.g. laptop CLI)"
                                        maxlength="64"
                                        required
                                        class="flex-1 min-w-[200px] px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
                                 <input type="number"
+                                       name="expires_in_days"
                                        id="key-expiry-input"
                                        placeholder="Expiry (days, optional)"
                                        min="1"
                                        max="365"
                                        class="w-48 px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
-                                <button type="button"
+                                <button type="submit"
                                         id="key-mint-btn"
-                                        onclick="mintApiKey()"
                                         class="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
                                     Create key
                                 </button>
                             </div>
+                        </form>
+
+                        <div id="key-mint-loader" class="htmx-indicator p-4">
+                          <div class="flex items-center space-x-3 bg-yellow-100 dark:bg-yellow-900/40 px-4 py-2 rounded-lg shadow-sm justify-center">
+                              <div class="spinner"></div>
+                              <span class="text-gray-600 dark:text-gray-300 font-medium">Creating key...</span>
+                          </div>
                         </div>
 
-                        <!-- Newly minted key display (shown once) -->
-                        <div id="key-mint-result" class="hidden mb-6 p-4 bg-green-100 dark:bg-green-900/40 border border-green-300 dark:border-green-700 rounded-lg">
-                            <p class="text-sm font-medium text-green-800 dark:text-green-200 mb-2">
-                                ⚠️ Copy this key now — it will not be shown again.
-                            </p>
-                            <code id="key-mint-value" class="block p-2 bg-white dark:bg-gray-800 border dark:border-gray-600 rounded text-sm font-mono break-all"></code>
-                            <button type="button"
-                                    onclick="copyApiKey()"
-                                    class="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline">
-                                Copy to clipboard
-                            </button>
-                        </div>
+                        <!-- The newly minted key is rendered here ONCE. Only its hash is
+                             stored, so no later fragment can show it again. -->
+                        <div id="key-mint-result" class="mb-6"></div>
 
-                        <!-- Key list -->
-                        <div id="key-list" class="space-y-2">
-                            <!-- Populated by loadApiKeys() -->
+                        <!-- The list renders its own empty state, so it is swapped whole.
+                             `key-minted from:body` catches the event the mint response
+                             triggers; a revoke targets this element directly. -->
+                        <div id="key-list"
+                             class="space-y-2"
+                             hx-get="/api/keys"
+                             hx-trigger="load, key-minted from:body"
+                             hx-swap="innerHTML"
+                             hx-indicator="#key-list-loader"></div>
+
+                        <div id="key-list-loader" class="htmx-indicator flex p-4">
+                          <div class="flex items-center space-x-3 bg-yellow-100 dark:bg-yellow-900/40 px-4 py-2 rounded-lg shadow-sm justify-center">
+                              <div class="spinner"></div>
+                              <span class="text-gray-600 dark:text-gray-300 font-medium">Loading keys...</span>
+                          </div>
                         </div>
-                        <p id="key-list-empty" class="hidden text-sm text-gray-500 dark:text-gray-400 italic">No API keys.</p>
                     </div>
                 </div><!-- /app-content -->
             </div>


### PR DESCRIPTION
Follow-up to #10. That PR added the API key panel; this one brings it in line with the
rest of the front end.

## Why

krtk.rs is HTMX/HATEOAS throughout — the shorten form, the links table and its
cursor pagination all `hx-*` their way to server-rendered fragments. The API key panel
was the one surface that did not: mint, list and revoke went through `fetch()`, with each
key row rebuilt as an HTML string in `main.js`.

That inconsistency had already cost two defects, both fixed in #10 after the fact:

- the client read `k.key_prefix` while the API serialises `prefix`, rendering `undefined`
  next to every key name;
- `new Date(k.expires_at)` fed epoch **seconds** to a **millisecond** constructor, so any
  key with an expiry would have shown a 1970 date.

Neither is expressible once the server owns the rendering. This is the class of bug going
away, not just the two instances.

## What changed

- **New templates** `shared/templates/api_keys_list.html` and `new_api_key.html` own the
  markup. The list renders its own empty state, so it can be swapped whole.
- **`manage_keys` negotiates on `Hx-Request`**, exactly as `create_link` and `get_links`
  already do. **The JSON API is not dropped** — `/api/keys` still answers JSON to a script
  holding a Cognito JWT.
- **Mint** answers with the one-time key banner plus `HX-Trigger: key-minted`. The list is
  subscribed via `hx-trigger="load, key-minted from:body"`, so *"a successful mint also
  changes the list"* is stated by the server rather than hardcoded in the page. The same
  event resets the form, which means a **rejected** mint keeps what you typed.
- **Revoke** is an `hx-delete` control the server emits per row, answering with the
  re-rendered list — deliberately not `204`, which htmx skips the swap on. It now also
  carries `hx-confirm`; the previous panel had no confirmation at all.
- **~150 lines of JavaScript deleted.** The panel has none: the only browser-API needs are
  the clipboard (reusing the page's existing `copyToClipboard`, as the links table always
  has) and `confirm` (via `hx-confirm`).

## Two things worth reviewing closely

**Mint now accepts a form body as well as JSON.** The form always submits
`expires_in_days`, as an *empty string* when left blank — the default case — which a plain
`Option<u32>` rejects with a parse error. So "Create key" would have `400`d on the most
common path while JSON callers stayed green. Hence `deserialize_optional_days`, pinned by a
test using the exact request the form sends.

**An HTMX revoke of a key the caller does not hold re-renders the list instead of
returning 403.** The list *is* the swap target, so an error fragment would destroy it. The
only way to reach that from the page is a list gone stale (already revoked in another
tab), where re-rendering is the outcome the user wanted. JSON callers still get the 403,
and nothing is deleted on either path — the ownership check is still the gate.

## Verification

- `cargo test --workspace` green — 39 in `shared`, 28 in `manage_keys` (17 of those new).
- `cargo clippy --workspace --all-targets` clean.
- 62 CDK tests pass.
- New tests cover fragment rendering, label escaping in **both** element-content and
  `hx-confirm` **attribute** context, form/JSON body parsing, the blank-expiry case, htmx
  detection, and that HTML error fragments mask internal detail the same way
  `error_response` does (a fragment is as public as a JSON body).
- The four htmx mechanisms this relies on were verified against htmx 1.9.10's source, the
  version the page pins: `HX-Trigger` dispatches on the requesting element, `triggerEvent`
  sets `bubbles: true`, `hx-on:` attributes are supported, and `from:body` is a valid
  modifier.

**Not verified:** nobody has looked at the rendered panel. The host this was built on has
no browser available, so there are no screenshots. Worth a click-through of mint → copy →
revoke, plus one rejected mint (blank label or the 10-key cap) to confirm the error
fragment lands and the form keeps its contents.
